### PR TITLE
Update email-validator in composer to ^2.0 because Drupal 8.7.2. won'…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     },
     "require": {
         "guzzlehttp/guzzle": ">=6.2.2",
-        "egulias/email-validator": "~1.2,>=1.2.1"
+        "egulias/email-validator": "^2.0"
     }
 }


### PR DESCRIPTION
Update email-validator in the composer to ^2.0 because of Drupal 8.7.2. won't accept the lower version.